### PR TITLE
Show roles bug

### DIFF
--- a/server/routes/volunteer.router.js
+++ b/server/routes/volunteer.router.js
@@ -16,7 +16,7 @@ router.get('/volunteer', rejectUnauthenticated, (req, res) => {
                     JOIN "lesson" ON "lesson"."id" = "slot"."lesson_id"
                     WHERE "date" < NOW()
                     GROUP BY "user"."id") AS "hours" ON "hours"."id" = "user"."id"
-                    ORDER BY "last_name", "first_name"
+                    ORDER BY "last_name", "first_name", "user"."id"
                     ; `;
 
     pool.query( sqlText )

--- a/server/routes/volunteer.router.js
+++ b/server/routes/volunteer.router.js
@@ -62,7 +62,8 @@ router.put( '/:selectedId', rejectUnauthenticated, async(req, res) => {
     const last_name = req.body.last_name;
     const phone = req.body.phone;
     const email = req.body.email;
-    const birthday = req.body.birthday;
+    let birthday = req.body.birthday;
+    if (birthday === 'Invalid date'){birthday = null};
     const availability_skills = [];
 
     // loop over the req.body and create an array of avalabilities and skills to insert in database.

--- a/src/components/ManageVolunteers/ManageVolunteers.js
+++ b/src/components/ManageVolunteers/ManageVolunteers.js
@@ -45,6 +45,10 @@ class ManageVolunteers extends Component {
     this.props.dispatch({type: 'FETCH_VOLUNTEERS'})
     this.props.dispatch ({ type: "GET_USER_ROLES"})
   }
+  componentDidUpdate(prevProps) {
+    if(prevProps.state.volunteer.volunteer !== this.props.state.volunteer.volunteer)
+    this.props.dispatch ({ type: 'GET_USER_ROLES'});
+  }
 
   render() {
     const { classes } = this.props

--- a/src/components/ManageVolunteers/RoleDropdown.js
+++ b/src/components/ManageVolunteers/RoleDropdown.js
@@ -71,6 +71,11 @@ class RoleDropdown extends React.Component {
   componentDidMount() {
     this.props.dispatch ({ type: "GET_USER_ROLES"})
   }
+  componentDidUpdate(prevProps){
+/*     if(){
+      this.props.dispatch ({ type: "GET_USER_ROLES"})
+    } */
+  }
 
   render() {
     const { classes } = this.props;


### PR DESCRIPTION
the manage volunteers table updates when roles are updated, and the lack of a birthday doesn't break the ability to change roles and availabilites (though max is working on preventing users to be added with no birthdays)
